### PR TITLE
 Fix schema translation for empty Messages 

### DIFF
--- a/src/test/protobuf/address_book.proto
+++ b/src/test/protobuf/address_book.proto
@@ -19,4 +19,8 @@ message Person {
     repeated PhoneNumber phone = 4;
 
     repeated string address = 5;
+
+    message EmptyMessage {}
+
+    optional EmptyMessage empty = 6;
 }

--- a/src/test/scala/com/github/saurfang/parquet/proto/spark/sql/ProtoRDDConversionSuite.scala
+++ b/src/test/scala/com/github/saurfang/parquet/proto/spark/sql/ProtoRDDConversionSuite.scala
@@ -1,12 +1,12 @@
 package com.github.saurfang.parquet.proto.spark.sql
 
 import com.github.saurfang.parquet.proto.AddressBook.Person
-import com.github.saurfang.parquet.proto.AddressBook.Person.PhoneNumber
+import com.github.saurfang.parquet.proto.AddressBook.Person.{EmptyMessage, PhoneNumber}
 import com.github.saurfang.parquet.proto.Simple.SimpleMessage
 import com.google.protobuf.ByteString
-import org.apache.spark.{SparkConf, SparkContext, LocalSparkContext}
+import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext}
 import org.apache.spark.sql.{Row, SQLContext}
-import org.scalatest.{Matchers, FunSuite}
+import org.scalatest.{FunSuite, Matchers}
 import ProtoRDDConversions._
 
 class ProtoRDDConversionSuite extends FunSuite with Matchers {
@@ -69,12 +69,12 @@ class ProtoRDDConversionSuite extends FunSuite with Matchers {
         .addPhone(PhoneNumber.newBuilder().setNumber("12345").setType(Person.PhoneType.MOBILE))
         .build
     val protoRow = messageToRow(protoMessage)
-    protoRow shouldBe Row("test", 0, null, Seq(Row("12345", "MOBILE")), Seq("ABC", "CDE"))
+    protoRow shouldBe Row("test", 0, null, Seq(Row("12345", "MOBILE")), Seq("ABC", "CDE"), null)
   }
 
   test("convert protobuf with empty repeated fields") {
     val protoMessage = Person.newBuilder().setName("test").setId(0).build()
     val protoRow = messageToRow(protoMessage)
-    protoRow shouldBe Row("test", 0, null, Seq(), Seq())
+    protoRow shouldBe Row("test", 0, null, Seq(), Seq(), null)
   }
 }


### PR DESCRIPTION
When translating a schema containing an empty message the library was issuing an error of type
```
java.lang.IllegalStateException: Cannot build an empty group
```

Empty messages are sometimes used to fill old deprecated fields.

Since parquet does not support empty structs, IMO empty messages can only be ignored.
[Link to a related spark issue](https://issues.apache.org/jira/browse/SPARK-20593?focusedCommentId=15996283&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15996283)